### PR TITLE
Fixes NodeJS incompatibility in Kibana version 6.6.1 Plugin Build

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,13 @@ if [ "$number_of_dots" == 2 ]
         KIBANA_BRANCH="${strarr[0]}.${strarr[1]}"
 fi
 
-NODE_VERSION=`curl -s https://raw.githubusercontent.com/elastic/kibana/$KIBANA_BRANCH/.node-version`
+echo -e "$INFO_COLOR Cloning Kibana Version: $KIBANA_VERSION $LOG_END"
+
+git clone --branch v$KIBANA_VERSION --depth 1 https://github.com/elastic/kibana /kibana
+
+echo $NEW_LINE
+
+NODE_VERSION=`cat /kibana/.node-version`
 
 if [ "$NODE_VERSION" == "404: Not Found" ]
     then
@@ -63,12 +69,6 @@ echo -e "$INFO_COLOR Install Node Dependencies $LOG_END"
 npm install -g yarn
 
 echo -e "$SUCCESS_COLOR Node Dependencies Installed Successfully. $LOG_END"
-
-echo $NEW_LINE
-
-echo -e "$INFO_COLOR Cloning Kibana Version: $KIBANA_VERSION $LOG_END"
-
-git clone --branch v$KIBANA_VERSION --depth 1 https://github.com/elastic/kibana /kibana
 
 echo $NEW_LINE
 


### PR DESCRIPTION
## Description
Get node version from tag in locally cloned kibana instead of the branch in the kibana public repo.

## Issues
resolves #1 

## Validation Steps
Run the following docker command to test the build for a plugin:

```
docker run -it -e KIBANA_VERSION=6.6.1 -e PLUGIN_VERSION=1.0.0-6.6.1 -v $KIBANA_PLUGIN_PATH:/kibana-extra/kibana-plugin --rm daniccan/kibana-plugin-builder
```
